### PR TITLE
Fixes invalid_grant error and bumps version

### DIFF
--- a/lib/omniauth-webflow/version.rb
+++ b/lib/omniauth-webflow/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Webflow
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -3,26 +3,24 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Webflow < OmniAuth::Strategies::OAuth2
-      API_VERSION = "1.0.0"
+      API_VERSION = '1.0.0'.freeze
 
-      option :name, "webflow"
+      option :name, 'webflow'
       option :client_options, {
-        site: "https://api.webflow.com",
+        site: 'https://api.webflow.com',
         authorize_url: 'https://webflow.com/oauth/authorize',
         token_url: 'https://api.webflow.com/oauth/access_token'
       }
-      # option :token_params, { parse: :json }
-      # option :auth_token_params, { mode: :query, param_name: :token }
 
       uid { raw_info['_id'] }
 
       info do
         {
-          id: raw_info["_id"],
-          grant_type: raw_info["grantType"],
-          users: raw_info["users"],
-          orgs: raw_info["orgs"],
-          sites: raw_info["sites"],
+          id: raw_info['_id'],
+          grant_type: raw_info['grantType'],
+          users: raw_info['users'],
+          orgs: raw_info['orgs'],
+          sites: raw_info['sites']
         }
       end
 
@@ -36,14 +34,17 @@ module OmniAuth
         @raw_info ||= access_token.get("https://api.webflow.com/info?api_version=#{API_VERSION}").parsed
       end
 
-    protected
+      protected
 
-      # had to override this method as it was merging the redirect_uri into the params which was breaking the Webflow /access_token request
+      # callback_url includes the code parameter and Webflow decided to change their API recently
+      # to require the redirect_uri to match exactly what you have in your Webflow Application settings.
+      # This also means that you can not pass other url parameters through the redirect_uri.
       def build_access_token
-        verifier = request.params["code"]
-        client.auth_code.get_token(verifier, token_params.to_hash(:symbolize_keys => true), deep_symbolize(options.auth_token_params))
+        verifier = request.params['code']
+        uri = Addressable::URI.parse(callback_url)
+        redirect_uri = uri.omit(:query).to_s
+        client.auth_code.get_token(verifier, { redirect_uri: redirect_uri }.merge(token_params.to_hash(symbolize_keys: true)), deep_symbolize(options.auth_token_params))
       end
-
     end
   end
 end


### PR DESCRIPTION
Webflow decided to change their API recently to require the redirect_uri to match exactly what you have in your Webflow Application settings.  Because the callback_url provided by omniauth includes the code parameter this breaks Webflows Oauth flow. This also means that you can not pass other url parameters through the redirect_uri.