### PR TITLE
v2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # omniauth-webflow
 
-This gem is an [OmniAuth 1.0](https://github.com/omniauth/omniauth) Strategy for authenticating with the [Webflow API](https://developers.webflow.com/) (version 1.0.0)
+This gem is an [OmniAuth](https://github.com/omniauth/omniauth) Strategy for authenticating with the [Webflow API](https://developers.webflow.com/)
 
 ## Setup
 
@@ -17,7 +17,7 @@ After registering a new application with Webflow take note of the `client_id` an
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'omniauth-webflow'
+gem 'omniauth-webflow', '~> 1.0.0'
 ```
 
 And then execute:
@@ -28,9 +28,12 @@ In your Rails app, add the Webflow provider to your Omniauth middleware, e.g. in
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :webflow, ENV['WEBFLOW_CLIENT_ID'], ENV['WEBFLOW_CLIENT_SECRET']
+  provider :webflow, ENV['WEBFLOW_CLIENT_ID'], ENV['WEBFLOW_CLIENT_SECRET'],
+  scope: 'authorized_user:read' # the scope is an example and not required
 end
 ```
+
+Specify [scopes](https://docs.developers.webflow.com/reference/scopes) as required.
 
 ## Contributing
 

--- a/lib/omniauth-webflow/version.rb
+++ b/lib/omniauth-webflow/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Webflow
-    VERSION = '0.2.1'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -1,5 +1,4 @@
 require 'omniauth-oauth2'
-require 'addressable/uri'
 
 module OmniAuth
   module Strategies

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -34,18 +34,6 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get("https://api.webflow.com/info?api_version=#{API_VERSION}").parsed
       end
-
-      protected
-
-      # callback_url includes the code parameter and Webflow decided to change their API recently
-      # to require the redirect_uri to match exactly what you have in your Webflow Application settings.
-      # This also means that you can not pass other url parameters through the redirect_uri.
-      def build_access_token
-        verifier = request.params['code']
-        uri = ::Addressable::URI.parse(callback_url)
-        redirect_uri = uri.omit(:query).to_s
-        client.auth_code.get_token(verifier, { redirect_uri: redirect_uri }.merge(token_params.to_hash(symbolize_keys: true)), deep_symbolize(options.auth_token_params))
-      end
     end
   end
 end

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -1,4 +1,5 @@
 require 'omniauth-oauth2'
+require 'addressable/uri'
 
 module OmniAuth
   module Strategies

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -41,7 +41,7 @@ module OmniAuth
       # This also means that you can not pass other url parameters through the redirect_uri.
       def build_access_token
         verifier = request.params['code']
-        uri = Addressable::URI.parse(callback_url)
+        uri = ::Addressable::URI.parse(callback_url)
         redirect_uri = uri.omit(:query).to_s
         client.auth_code.get_token(verifier, { redirect_uri: redirect_uri }.merge(token_params.to_hash(symbolize_keys: true)), deep_symbolize(options.auth_token_params))
       end

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -11,6 +11,10 @@ module OmniAuth
         authorize_url: 'https://webflow.com/oauth/authorize',
         token_url: 'https://api.webflow.com/oauth/access_token'
       }
+      option :token_options, {
+        client_id: options.client_id,
+        client_secret: options.client_secret,
+      }
 
       uid { raw_info['_id'] }
 

--- a/lib/omniauth/strategies/webflow.rb
+++ b/lib/omniauth/strategies/webflow.rb
@@ -3,29 +3,17 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Webflow < OmniAuth::Strategies::OAuth2
-      API_VERSION = '1.0.0'.freeze
-
       option :name, 'webflow'
       option :client_options, {
         site: 'https://api.webflow.com',
         authorize_url: 'https://webflow.com/oauth/authorize',
         token_url: 'https://api.webflow.com/oauth/access_token'
       }
-      option :token_options, {
-        client_id: options.client_id,
-        client_secret: options.client_secret,
-      }
 
-      uid { raw_info['_id'] }
+      uid { raw_info['authorization']['id'] }
 
       info do
-        {
-          id: raw_info['_id'],
-          grant_type: raw_info['grantType'],
-          users: raw_info['users'],
-          orgs: raw_info['orgs'],
-          sites: raw_info['sites']
-        }
+        raw_info['authorization']
       end
 
       extra do
@@ -35,7 +23,18 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get("https://api.webflow.com/info?api_version=#{API_VERSION}").parsed
+        @raw_info ||= access_token.get("/v2/token/introspect").parsed
+      end
+
+      def token_params
+        super.merge({
+          client_id: options.client_id,
+          client_secret: options.client_secret,
+        })
+      end
+
+      def callback_url
+        full_host + callback_path
       end
     end
   end

--- a/omniauth-webflow.gemspec
+++ b/omniauth-webflow.gemspec
@@ -27,9 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # spec.add_runtime_dependency 'omniauth-oauth2'
-  # spec.add_runtime_dependency 'multi_json'
-
   spec.add_dependency 'omniauth-oauth2', '~> 1.7'
   spec.add_dependency 'multi_json', '~> 1.15'
+  spec.add_dependency 'addressable', '~> 2.7'
 end

--- a/omniauth-webflow.gemspec
+++ b/omniauth-webflow.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.7'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.8'
   spec.add_dependency 'multi_json', '~> 1.15'
 end

--- a/omniauth-webflow.gemspec
+++ b/omniauth-webflow.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.8'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.7'
   spec.add_dependency 'multi_json', '~> 1.15'
 end

--- a/omniauth-webflow.gemspec
+++ b/omniauth-webflow.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '~> 1.7'
   spec.add_dependency 'multi_json', '~> 1.15'
-  spec.add_dependency 'addressable', '~> 2.7'
 end


### PR DESCRIPTION
Updates the gem to the current Webflow OAuth and API implementations.
* required `client_id` and `client_secret` parameters added to the `/oauth/access_token` call
* refactored to remove dependency on `Addressable::URI`
* `scope` added to README, assorted edits to remove outdated versions
* user info call changed to v2 API
* major version incremented due to incompatible user info format